### PR TITLE
Fix: Bugs affecting dynamic versioning support

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -38,33 +38,61 @@ jobs:
           path: 'test-python-project'
 
       - name: "Run action: ${{ github.repository }}"
-        id: testing
+        id: test-static
+        uses: ./
+        with:
+          path_prefix: 'test-python-project'
+
+      - name: "Update pyproject.toml for dynamic versioning"
+        shell: bash
+        run: |
+          # Update pyproject.toml for dynamic versioning
+          echo "Copying dynamic pyproject.toml to test-python-project"
+          cp resources/dynamic-pyproject.toml test-python-project/pyproject.toml
+
+      - name: "Run action: ${{ github.repository }}"
+        id: test-dynamic
         uses: ./
         with:
           path_prefix: 'test-python-project'
 
       - name: "Validate action output: ${{ github.repository }}"
         shell: bash
+        # yamllint disable rule:line-length
         run: |
           # Validate Action Output
-          if [ "${{ steps.testing.outputs.python_project_file }}" \
+          if [ "${{ steps.test-static.outputs.python_project_file }}" \
             != "pyproject.toml" ]; then
             echo 'Unexpected return value for: python_project_file ❌'
-            echo "Returned: ${{ steps.testing.outputs.python_project_file }}"
+            echo "Returned: ${{ steps.test-static.outputs.python_project_file }}"
             echo 'Expected: pyproject.toml'
             ERROR='true'
           fi
-          if [ "${{ steps.testing.outputs.python_project_name }}" \
+          if [ "${{ steps.test-static.outputs.versioning_type }}" \
+            != "static" ]; then
+            echo 'Unexpected return value for: versioning_type ❌'
+            echo "Returned: ${{ steps.test-static.outputs.versioning_type }}"
+            echo 'Expected: static'
+            ERROR='true'
+          fi
+          if [ "${{ steps.test-dynamic.outputs.versioning_type }}" \
+            != "dynamic" ]; then
+            echo 'Unexpected return value for: versioning_type ❌'
+            echo "Returned: ${{ steps.test-dynamic.outputs.versioning_type }}"
+            echo 'Expected: dynamic'
+            ERROR='true'
+          fi
+          if [ "${{ steps.test-static.outputs.python_project_name }}" \
             != 'lfreleng-test-python-project' ]; then
             echo 'Unexpected return value for: python_project_name ❌'
-            echo "Returned: ${{ steps.testing.outputs.python_project_name }}"
+            echo "Returned: ${{ steps.test-static.outputs.python_project_name }}"
             echo 'Expected: lfreleng-test-python-project'
             ERROR='true'
           fi
-          if [ "${{ steps.testing.outputs.python_package_name }}" \
+          if [ "${{ steps.test-static.outputs.python_package_name }}" \
             != 'lfreleng_test_python_project' ]; then
             echo 'Unexpected return value for: python_package_name ❌'
-            echo "Returned: ${{ steps.testing.outputs.python_project_name }}"
+            echo "Returned: ${{ steps.test-static.outputs.python_project_name }}"
             echo 'Expected: lfreleng_test_python_project'
             ERROR='true'
           fi

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ Extracts Python project metadata from a repository.
 | ---------------------- | -------------------------------------------------------- |
 | python_project_file    | File used to define/describe the project                 |
 | python_project_name    | The name of the Python project                           |
+| versioning_type        | Can be either static or dynamic (determined by tags)     |
 | python_project_version | The name of the Python project                           |
 | python_package_name    | The name of the Python package                           |
 | project_match_package  | Set true when the project and package name match         |
 | project_match_repo     | Set true when the project name and repository name match |
-| versioning_type        | Can be either static or dynamic (determined by tags)     |
 | build_python           | Most recent Python version supported by project          |
 | matrix_json            | All Python versions supported by project as JSON string  |
 

--- a/action.yaml
+++ b/action.yaml
@@ -22,6 +22,9 @@ outputs:
   python_project_name:
     description: "The name of the Python project"
     value: ${{ steps.project-name.outputs.python_project_name }}
+  versioning_type:
+    description: "Project supported Python versions as JSON"
+    value: ${{ steps.versioning.outputs.type }}
   python_project_version:
     description: "The version of the Python project"
     value: ${{ steps.project-version.outputs.python_project_version }}
@@ -35,9 +38,6 @@ outputs:
   project_match_repo:
     description: "Set true when the project name and repository name match"
     value: ${{ steps.compare.outputs.project_match_repo }}
-  versioning_type:
-    description: "Project supported Python versions as JSON"
-    value: ${{ steps.versioning-type.outputs.versioning_type }}
   matrix_json:
     description: "Project supported Python versions as JSON"
     value: ${{ steps.supported-python-versions.outputs.matrix_json }}
@@ -65,7 +65,29 @@ runs:
       with:
         path_prefix: "${{ inputs.path_prefix }}"
 
+    - name: 'Check if pyproject.toml uses dynamic versioning'
+      id: dyn-check
+      # yamllint disable-line rule:line-length
+      uses: lfreleng-actions/python-dynamic-version-action@757278a7dce3add2c777305e7ec61d9e2b97ed7e # v0.1.6
+      with:
+        path_prefix: "${{ inputs.path_prefix }}"
+
+    - name: 'Determine versioning type [static|dynamic]'
+      id: versioning
+      shell: bash
+      run: |
+        # Determine versioning type [static|dynamic]
+        if [ "${{ steps.dyn-check.outputs.dynamic_version }}" = 'true' ]; then
+          echo "type=dynamic" >> "$GITHUB_ENV"
+          echo "type=dynamic" >> "$GITHUB_OUTPUT"
+        else
+          echo 'Static versioning enabled ✅'
+          echo "type=static" >> "$GITHUB_ENV"
+          echo "type=static" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: 'Extract Python project version'
+      if: steps.dyn-check.outputs.dynamic_version == 'false'
       id: project-version
       # yamllint disable-line rule:line-length
       uses: lfreleng-actions/python-project-version-action@9c74e1e9686c9b16cc8e5ba3621efe616703d965 # v0.1.4
@@ -101,14 +123,6 @@ runs:
         echo "project_match_repo=$names_match" >> "$GITHUB_ENV"
         echo "project_match_repo=$names_match" >> "$GITHUB_OUTPUT"
 
-    - name: 'Determine versioning type [static|dynamic]'
-      if: steps.project-toml.outputs.type == 'file'
-      id: dynamic-versioning
-      # yamllint disable-line rule:line-length
-      uses: lfreleng-actions/python-dynamic-version-action@757278a7dce3add2c777305e7ec61d9e2b97ed7e # v0.1.6
-      with:
-        path_prefix: "${{ inputs.path_prefix }}"
-
     - name: 'Get project supported Python versions'
       id: supported-python-versions
       # yamllint disable-line rule:line-length
@@ -121,13 +135,21 @@ runs:
       # yamllint disable rule:line-length
       run: |
         # Display summary output
+
+        # Set displayed value based on static or dynamic versioning
+        if [ "${{ steps.versioning.outputs.type }}" = "dynamic" ]; then
+          DISPLAY_VERSION='dynamic'
+        else
+          DISPLAY_VERSION="${{ steps.project-version.outputs.python_project_version }}"
+        fi
+
         echo '### Project Information' >> "$GITHUB_STEP_SUMMARY"
 
         echo '| Key | Value |' >> "$GITHUB_STEP_SUMMARY"
         echo '| ----------------- | ------- |' >> "$GITHUB_STEP_SUMMARY"
         echo "| Metadata source | ${{ steps.project-name.outputs.python_project_file }} |" >> "$GITHUB_STEP_SUMMARY"
         echo "| Project name | ${{ steps.project-name.outputs.python_project_name }} |" >> "$GITHUB_STEP_SUMMARY"
-        echo "| Project version | ${{ steps.project-version.outputs.python_project_version }} |" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Project version | "$DISPLAY_VERSION" |" >> "$GITHUB_STEP_SUMMARY"
         echo "| Package name | ${{ steps.project-name.outputs.python_package_name }} |" >> "$GITHUB_STEP_SUMMARY"
         echo "| Build Python | ${{ steps.supported-python-versions.outputs.build_python }} |" >> "$GITHUB_STEP_SUMMARY"
         echo "| Matrix JSON | ${{ steps.supported-python-versions.outputs.matrix_json }} |" >> "$GITHUB_STEP_SUMMARY"

--- a/resources/dynamic-pyproject.toml
+++ b/resources/dynamic-pyproject.toml
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+[project]
+name = "lfreleng-test-python-project"
+dynamic = ["version"]
+description = "Sample Python project used for testing actions"
+authors = [
+    {name = "Matthew Watkins", email = "93649628+ModeSevenIndustrialSolutions@users.noreply.github.com"},
+]
+dependencies = ["typer>=0.15.2", "jupyterlab>=4.3.6"]
+requires-python = "<3.13,>=3.11"
+readme = "README.md"
+license = {text = "Apache-2.0"}
+classifiers = [
+  "Intended Audience :: Developers",
+  "Intended Audience :: Science/Research",
+  "License :: OSI Approved :: Apache Software License",
+  "Operating System :: MacOS",
+  "Operating System :: Microsoft :: Windows",
+  "Operating System :: Unix",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.11",
+  "Topic :: Office/Business :: Financial",
+  "Topic :: Scientific/Engineering",
+  "Topic :: Software Development",
+]
+
+[project.scripts]
+lfreleng-test-python-project = "lfreleng_test_python_project.cli:run"
+
+[build-system]
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
+
+
+[tool.pdm]
+distribution = true
+
+[dependency-groups]
+test = [
+    "pytest>=8.3.5",
+    "coverage>=7.7.1",
+]
+tox = [
+    "tox>=4.24.2",
+    "tox-pdm>=0.7.2",
+]
+lint = [
+    "pre-commit>=4.2.0",
+]
+docs = [
+    "sphinx>=8.2.3",
+    "sphinx-copybutton>=0.5.2",
+]


### PR DESCRIPTION
Sequencing issue, where project version was extracted before checking if dynamic versioning was enabled in the project. The subsequent RegEx to extract the version string would then fail, causing the workflow to abort.
    
There were also some references to a missing implementation and no tests against a pyproject.toml file for dynamic projects. The tests have been put in place by copying a pyproject.toml with the required directive, then invoking the action again.