### PR TITLE
Chore: Bump python action pins to latest releases

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -60,7 +60,7 @@ runs:
     - name: 'Extract Python project name'
       id: project-name
       # yamllint disable-line rule:line-length
-      uses: lfreleng-actions/python-project-name-action@a8287d8627a34a40aacc33f73348dfb0b47b6cea # v0.1.5
+      uses: lfreleng-actions/python-project-name-action@9f2cc7d37847d5f5497ba87d14e574b2f0a07462 # v0.1.6
       with:
         path_prefix: "${{ inputs.path_prefix }}"
 
@@ -125,7 +125,7 @@ runs:
     - name: 'Get project supported Python versions'
       id: supported-python-versions
       # yamllint disable-line rule:line-length
-      uses: lfreleng-actions/python-supported-versions-action@55afbeffb9162574b10f8c6f89c3ba931db77c0f # v0.1.11
+      uses: lfreleng-actions/python-supported-versions-action@78063d3b1de85859b934d1740036fa3bf3e6c45f # v0.2.0
       with:
         path_prefix: "${{ inputs.path_prefix }}"
 


### PR DESCRIPTION
## Summary

Bumps two pinned `lfreleng-actions/...` dependency actions to their latest
releases. Pin-only change; no other files touched.

## Bumps

- `lfreleng-actions/python-project-name-action`: **v0.1.5 → v0.1.6**
  - Adds `setup.cfg [metadata] name` extraction for legacy / pbr projects.
  - Pure addition to extraction sources — outputs (`python_project_name`,
    `python_package_name`, `python_project_file`) consumed here are unchanged.
  - Release: https://github.com/lfreleng-actions/python-project-name-action/releases/tag/v0.1.6

- `lfreleng-actions/python-supported-versions-action`: **v0.1.11 → v0.2.0**
  - Adds support for legacy projects without `pyproject.toml`, EOL-aware
    fallback when no constraint is declared, plus a new `versions_source`
    output and `default_python_version` input.
  - All changes are additive — the `build_python` and `matrix_json` outputs
    consumed here are unchanged.
  - Release: https://github.com/lfreleng-actions/python-supported-versions-action/releases/tag/v0.2.0

## Compatibility

No breaking changes affect this caller. Both upstream releases are additive
relative to the outputs / inputs this action uses. No corresponding code
changes required beyond the two `uses:` SHA pins.