### PR TITLE
Fix: project_match_repo mismatch and invalid step ids in summary

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -116,7 +116,7 @@ runs:
           names_match="true"
           echo 'Project and repository names are identical ✅'
         else
-          names_match='true'
+          names_match='false'
           echo 'Project and repository names are NOT identical ⚠️'
         fi
         echo "project_match_repo=$names_match" >> "$GITHUB_ENV"
@@ -152,6 +152,6 @@ runs:
         echo "| Package name | ${{ steps.project-name.outputs.python_package_name }} |" >> "$GITHUB_STEP_SUMMARY"
         echo "| Build Python | ${{ steps.supported-python-versions.outputs.build_python }} |" >> "$GITHUB_STEP_SUMMARY"
         echo "| Matrix JSON | ${{ steps.supported-python-versions.outputs.matrix_json }} |" >> "$GITHUB_STEP_SUMMARY"
-        if [ "${{ steps.project-toml.outputs.type }}" = "file" ]; then
-          echo "| Dynamic versioning | ${{ steps.dynamic-versioning.outputs.dynamic_version }} |" >> "$GITHUB_STEP_SUMMARY"
+        if [ "${{ steps.dyn-check.outputs.dynamic_version }}" != '' ]; then
+          echo "| Dynamic versioning | ${{ steps.dyn-check.outputs.dynamic_version }} |" >> "$GITHUB_STEP_SUMMARY"
         fi


### PR DESCRIPTION
## Summary

Two latent bugs in the workflow summary / output computation:

### 1. `project_match_repo` always reports `true`

In the "Compare project and package/repository names" step the **else** branch sets `names_match='true'` instead of `'false'`:

```yaml
if [ "${{ steps.project-name.outputs.python_project_name }}" = "$REPO_NAME" ]; then
  names_match="true"
  echo 'Project and repository names are identical ✅'
else
  names_match='true'      # <-- copy-paste bug
  echo 'Project and repository names are NOT identical ⚠️'
fi
```

So the output `project_match_repo` reports `true` regardless of whether the project name actually matches the repository name. The package-name comparison immediately above already had the correct pattern; this was a straight copy-paste-and-forget bug.

### 2. Summary's "Dynamic versioning" row never renders

The summary gated on `steps.project-toml.outputs.type == 'file'` and emitted `steps.dynamic-versioning.outputs.dynamic_version`. Neither step id exists in this composite action; the actual step ids are `dyn-check`, `versioning`, `project-version`, `project-name`, `compare`, `supported-python-versions`. There is no path-check step. The row therefore never rendered.

Fix: reference the existing `steps.dyn-check.outputs.dynamic_version` output, gated on its presence (so the row renders for any project layout the action handles, not only `pyproject.toml`-based ones).

## Diff

```diff
-          names_match='true'
+          names_match='false'
           echo 'Project and repository names are NOT identical ⚠️'
```

```diff
-        if [ "${{ steps.project-toml.outputs.type }}" = "file" ]; then
-          echo "| Dynamic versioning | ${{ steps.dynamic-versioning.outputs.dynamic_version }} |"
+        if [ "${{ steps.dyn-check.outputs.dynamic_version }}" != '' ]; then
+          echo "| Dynamic versioning | ${{ steps.dyn-check.outputs.dynamic_version }} |"
         fi
```

## Note

These bugs surfaced as part of a broader audit of the Python actions portfolio (lfreleng-actions/build-metadata-action#70, lfreleng-actions/python-project-version-action#110, lfreleng-actions/python-dynamic-version-action#100, lfreleng-actions/python-build-action#182). `python-project-metadata-action` is effectively superseded by `build-metadata-action` as the canonical metadata source for new pipelines, but it remains in use and so deserves a correctness fix.
