### PR TITLE
Chore: sync linting setup from actions-template

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,7 +17,7 @@ indent_size = 2
 max_line_length = 80
 
 [*.py]
-max_line_legth = 120
+max_line_length = 120
 
 [*.sh]
 max_line_length = 80

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -24,6 +24,7 @@ jobs:
   tests:
     name: 'Action Testing'
     runs-on: 'ubuntu-24.04'
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,16 @@
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 ci:
-  autofix_commit_msg: "Chore: pre-commit autoupdate"
+  # pre-commit.ci sandbox prevents network calls; disable gha-workflow-linter
+  skip: [gha-workflow-linter]
+  autofix_commit_msg: |
+    Chore: pre-commit autofixes
+
+    Signed-off-by: pre-commit-ci[bot] <pre-commit-ci@users.noreply.github.com>
+  autoupdate_commit_msg: |
+    Chore: pre-commit autoupdate
+
+    Signed-off-by: pre-commit-ci[bot] <pre-commit-ci@users.noreply.github.com>
 
 exclude: "^docs/conf.py"
 
@@ -90,3 +99,29 @@ repos:
     rev: 2ccb47ff45ad361a21071a7eedda4c37e6ae8c5a  # frozen: v2.4.2
     hooks:
       - id: codespell
+
+  # Requires a mirror, primary repo lacks .pre-commit-hooks.yaml
+  - repo: https://github.com/DetachHead/basedpyright-prek-mirror
+    rev: 1a17bc2de06c96f36d9285331bf7fc2e399804d6  # frozen: 1.39.7
+    hooks:
+      - id: basedpyright
+
+  - repo: https://github.com/lfreleng-actions/gha-workflow-linter
+    rev: 2c315e461ec3379bf9c1682360fdc1a3899f88c9  # frozen: v1.0.4
+    hooks:
+      - id: gha-workflow-linter
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 943377262562a12b57292fc98fabd7dbf81451fe  # frozen: 0.37.2
+    hooks:
+      - id: check-github-actions
+      - id: check-github-workflows
+      - id: check-jsonschema
+        name: Check GitHub Workflows set timeout-minutes
+        args:
+          - --builtin-schema
+          - github-workflows-require-timeout
+        files: ^\.github/workflows/[^/]+$
+        types:
+          - yaml
+      - id: check-readthedocs


### PR DESCRIPTION
## Summary

Imports the pre-commit linting configuration verbatim from the
[`actions-template`](https://github.com/lfreleng-actions/actions-template)
repository to bring this project in line with the shared standard.

## Motivation

pre-commit.ci recently raised an autoupdate PR (#135) with the default
title `[pre-commit.ci] pre-commit autoupdate`, which the semantic pull
request title check rejects because it has no Conventional Commit
prefix. The root cause is that the local `.pre-commit-config.yaml` was
missing an `autoupdate_commit_msg` setting (the existing
`autofix_commit_msg` was also mislabelled). Without it, pre-commit.ci
falls back to its default, non-conventional title.

## Changes

`.pre-commit-config.yaml` (synced from template):
- Adds `autoupdate_commit_msg` and corrects `autofix_commit_msg`, both
  with a `Chore:` prefix and a `Signed-off-by` DCO trailer so future
  bot PRs pass the semantic-title gate.
- Adds `skip: [gha-workflow-linter]` for the pre-commit.ci sandbox
  (which blocks the network calls that hook makes).
- Adds the `basedpyright`, `gha-workflow-linter` and `check-jsonschema`
  (`check-github-actions`, `check-github-workflows`, workflow
  timeout-minutes, `check-readthedocs`) hooks.

`.editorconfig` (synced from template):
- Fixes the `max_line_legth` → `max_line_length` typo for `*.py`.

`.gitlint` and `.yamllint` were copied too but are byte-identical to the
existing files (no change).

## Validation

`pre-commit` ran on commit; all newly added hooks installed and executed
without error.
