### PR TITLE
Fix: Env-mediate expressions in run blocks

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -74,38 +74,38 @@ jobs:
         # yamllint disable rule:line-length
         run: |
           # Validate Action Output
-          if [ "${{ steps.test-static.outputs.python_project_file }}" \
+          if [ "${STEPS_TEST_STATIC_OUTPUTS_PYTHON_PROJECT_FILE}" \
             != "pyproject.toml" ]; then
             echo 'Unexpected return value for: python_project_file ❌'
-            echo "Returned: ${{ steps.test-static.outputs.python_project_file }}"
+            echo "Returned: ${STEPS_TEST_STATIC_OUTPUTS_PYTHON_PROJECT_FILE}"
             echo 'Expected: pyproject.toml'
             ERROR='true'
           fi
-          if [ "${{ steps.test-static.outputs.versioning_type }}" \
+          if [ "${STEPS_TEST_STATIC_OUTPUTS_VERSIONING_TYPE}" \
             != "static" ]; then
             echo 'Unexpected return value for: versioning_type ❌'
-            echo "Returned: ${{ steps.test-static.outputs.versioning_type }}"
+            echo "Returned: ${STEPS_TEST_STATIC_OUTPUTS_VERSIONING_TYPE}"
             echo 'Expected: static'
             ERROR='true'
           fi
-          if [ "${{ steps.test-dynamic.outputs.versioning_type }}" \
+          if [ "${STEPS_TEST_DYNAMIC_OUTPUTS_VERSIONING_TYPE}" \
             != "dynamic" ]; then
             echo 'Unexpected return value for: versioning_type ❌'
-            echo "Returned: ${{ steps.test-dynamic.outputs.versioning_type }}"
+            echo "Returned: ${STEPS_TEST_DYNAMIC_OUTPUTS_VERSIONING_TYPE}"
             echo 'Expected: dynamic'
             ERROR='true'
           fi
-          if [ "${{ steps.test-static.outputs.python_project_name }}" \
+          if [ "${STEPS_TEST_STATIC_OUTPUTS_PYTHON_PROJECT_NAME}" \
             != 'lfreleng-test-python-project' ]; then
             echo 'Unexpected return value for: python_project_name ❌'
-            echo "Returned: ${{ steps.test-static.outputs.python_project_name }}"
+            echo "Returned: ${STEPS_TEST_STATIC_OUTPUTS_PYTHON_PROJECT_NAME}"
             echo 'Expected: lfreleng-test-python-project'
             ERROR='true'
           fi
-          if [ "${{ steps.test-static.outputs.python_package_name }}" \
+          if [ "${STEPS_TEST_STATIC_OUTPUTS_PYTHON_PACKAGE_NAME}" \
             != 'lfreleng_test_python_project' ]; then
             echo 'Unexpected return value for: python_package_name ❌'
-            echo "Returned: ${{ steps.test-static.outputs.python_project_name }}"
+            echo "Returned: ${STEPS_TEST_STATIC_OUTPUTS_PYTHON_PACKAGE_NAME}"
             echo 'Expected: lfreleng_test_python_project'
             ERROR='true'
           fi
@@ -115,3 +115,9 @@ jobs:
             echo 'At least one test failed ❌'
             exit 1
           fi
+        env:
+          STEPS_TEST_STATIC_OUTPUTS_PYTHON_PROJECT_FILE: ${{ steps.test-static.outputs.python_project_file }}
+          STEPS_TEST_STATIC_OUTPUTS_VERSIONING_TYPE: ${{ steps.test-static.outputs.versioning_type }}
+          STEPS_TEST_DYNAMIC_OUTPUTS_VERSIONING_TYPE: ${{ steps.test-dynamic.outputs.versioning_type }}
+          STEPS_TEST_STATIC_OUTPUTS_PYTHON_PROJECT_NAME: ${{ steps.test-static.outputs.python_project_name }}
+          STEPS_TEST_STATIC_OUTPUTS_PYTHON_PACKAGE_NAME: ${{ steps.test-static.outputs.python_package_name }}

--- a/action.yaml
+++ b/action.yaml
@@ -78,12 +78,15 @@ runs:
       shell: bash
       run: |
         # Determine versioning type [static|dynamic]
-        if [ "${{ steps.dyn-check.outputs.dynamic_version }}" = 'true' ]; then
+        if [ "${STEPS_DYN_CHECK_OUTPUTS_DYNAMIC_VERSION}" = 'true' ]; then
           echo "type=dynamic" >> "$GITHUB_OUTPUT"
         else
           echo 'Static versioning enabled ✅'
           echo "type=static" >> "$GITHUB_OUTPUT"
         fi
+      env:
+        # yamllint disable-line rule:line-length
+        STEPS_DYN_CHECK_OUTPUTS_DYNAMIC_VERSION: ${{ steps.dyn-check.outputs.dynamic_version }}
 
     - name: 'Extract Python project version'
       if: steps.dyn-check.outputs.dynamic_version == 'false'
@@ -98,8 +101,8 @@ runs:
       shell: bash
       run: |
         # Compare project and package names
-        if [ "${{ steps.project-name.outputs.python_project_name }}" = \
-          "${{ steps.project-name.outputs.python_package_name }}" ]; then
+        if [ "${STEPS_PROJECT_NAME_OUTPUTS_PYTHON_PROJECT_NAME}" = \
+          "${STEPS_PROJECT_NAME_OUTPUTS_PYTHON_PACKAGE_NAME}" ]; then
           names_match='true'
           echo 'Project and package names are identical ✅'
         else
@@ -110,7 +113,7 @@ runs:
 
         # Compare project and repository names
         REPO_NAME=${GITHUB_REPOSITORY#$GITHUB_REPOSITORY_OWNER/}
-        if [ "${{ steps.project-name.outputs.python_project_name }}" = \
+        if [ "${STEPS_PROJECT_NAME_OUTPUTS_PYTHON_PROJECT_NAME}" = \
           "$REPO_NAME" ]; then
           names_match="true"
           echo 'Project and repository names are identical ✅'
@@ -119,6 +122,11 @@ runs:
           echo 'Project and repository names are NOT identical ⚠️'
         fi
         echo "project_match_repo=$names_match" >> "$GITHUB_OUTPUT"
+      env:
+        # yamllint disable-line rule:line-length
+        STEPS_PROJECT_NAME_OUTPUTS_PYTHON_PROJECT_NAME: ${{ steps.project-name.outputs.python_project_name }}
+        # yamllint disable-line rule:line-length
+        STEPS_PROJECT_NAME_OUTPUTS_PYTHON_PACKAGE_NAME: ${{ steps.project-name.outputs.python_package_name }}
 
     - name: 'Get project supported Python versions'
       id: supported-python-versions
@@ -134,22 +142,31 @@ runs:
         # Display summary output
 
         # Set displayed value based on static or dynamic versioning
-        if [ "${{ steps.versioning.outputs.type }}" = "dynamic" ]; then
+        if [ "${STEPS_VERSIONING_OUTPUTS_TYPE}" = "dynamic" ]; then
           DISPLAY_VERSION='dynamic'
         else
-          DISPLAY_VERSION="${{ steps.project-version.outputs.python_project_version }}"
+          DISPLAY_VERSION="${STEPS_PROJECT_VERSION_OUTPUTS_PYTHON_PROJECT_VERSION}"
         fi
 
         echo '### Project Information' >> "$GITHUB_STEP_SUMMARY"
 
         echo '| Key | Value |' >> "$GITHUB_STEP_SUMMARY"
         echo '| ----------------- | ------- |' >> "$GITHUB_STEP_SUMMARY"
-        echo "| Metadata source | ${{ steps.project-name.outputs.python_project_file }} |" >> "$GITHUB_STEP_SUMMARY"
-        echo "| Project name | ${{ steps.project-name.outputs.python_project_name }} |" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Metadata source | ${STEPS_PROJECT_NAME_OUTPUTS_PYTHON_PROJECT_FILE} |" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Project name | ${STEPS_PROJECT_NAME_OUTPUTS_PYTHON_PROJECT_NAME} |" >> "$GITHUB_STEP_SUMMARY"
         echo "| Project version | "$DISPLAY_VERSION" |" >> "$GITHUB_STEP_SUMMARY"
-        echo "| Package name | ${{ steps.project-name.outputs.python_package_name }} |" >> "$GITHUB_STEP_SUMMARY"
-        echo "| Build Python | ${{ steps.supported-python-versions.outputs.build_python }} |" >> "$GITHUB_STEP_SUMMARY"
-        echo "| Matrix JSON | ${{ steps.supported-python-versions.outputs.matrix_json }} |" >> "$GITHUB_STEP_SUMMARY"
-        if [ "${{ steps.dyn-check.outputs.dynamic_version }}" != '' ]; then
-          echo "| Dynamic versioning | ${{ steps.dyn-check.outputs.dynamic_version }} |" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Package name | ${STEPS_PROJECT_NAME_OUTPUTS_PYTHON_PACKAGE_NAME} |" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Build Python | ${STEPS_SUPPORTED_PYTHON_VERSIONS_OUTPUTS_BUILD_PYTHON} |" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Matrix JSON | ${STEPS_SUPPORTED_PYTHON_VERSIONS_OUTPUTS_MATRIX_JSON} |" >> "$GITHUB_STEP_SUMMARY"
+        if [ "${STEPS_DYN_CHECK_OUTPUTS_DYNAMIC_VERSION}" != '' ]; then
+          echo "| Dynamic versioning | ${STEPS_DYN_CHECK_OUTPUTS_DYNAMIC_VERSION} |" >> "$GITHUB_STEP_SUMMARY"
         fi
+      env:
+        STEPS_VERSIONING_OUTPUTS_TYPE: ${{ steps.versioning.outputs.type }}
+        STEPS_PROJECT_VERSION_OUTPUTS_PYTHON_PROJECT_VERSION: ${{ steps.project-version.outputs.python_project_version }}
+        STEPS_PROJECT_NAME_OUTPUTS_PYTHON_PROJECT_FILE: ${{ steps.project-name.outputs.python_project_file }}
+        STEPS_PROJECT_NAME_OUTPUTS_PYTHON_PROJECT_NAME: ${{ steps.project-name.outputs.python_project_name }}
+        STEPS_PROJECT_NAME_OUTPUTS_PYTHON_PACKAGE_NAME: ${{ steps.project-name.outputs.python_package_name }}
+        STEPS_SUPPORTED_PYTHON_VERSIONS_OUTPUTS_BUILD_PYTHON: ${{ steps.supported-python-versions.outputs.build_python }}
+        STEPS_SUPPORTED_PYTHON_VERSIONS_OUTPUTS_MATRIX_JSON: ${{ steps.supported-python-versions.outputs.matrix_json }}
+        STEPS_DYN_CHECK_OUTPUTS_DYNAMIC_VERSION: ${{ steps.dyn-check.outputs.dynamic_version }}


### PR DESCRIPTION
## Why

`zizmor`'s `template-injection` audit reports GitHub expressions that expand directly inside `run:` blocks. The expansion happens *before* the shell sees the script, so a value carrying shell syntax becomes code rather than data.

Each expression now reaches the shell through the step environment instead. These findings predate the change to the organisation `zizmor` floor (`low` → `informational`); they were simply below the old threshold.

## Please review the diff carefully

The transformation is not purely mechanical. Swapping `${{ expr }}` for `${VAR}` **changes the quoting rules**, because the original was substituted by GitHub before the shell ran and the replacement is an ordinary shell variable. Three contexts silently stop working:

| Context | Before | After |
| ------- | ------ | ----- |
| `var='${{ expr }}'` | substituted by GitHub | **literal string** |
| `echo 'text ${{ expr }}'` | substituted by GitHub | **literal string** |
| `cat <<'EOF'` … `${{ expr }}` | substituted by GitHub | **literal string** |

`shellcheck` catches the first two. **It does not catch the heredoc case.** That one was found in `url-validity-action`, where 27 references would have rendered the job summary as variable names instead of results.

## What was verified before raising this

- `zizmor --persona auditor --min-severity informational` — no findings
- `actionlint` (including shellcheck) — clean
- `yamllint` — clean
- A purpose-built audit for generated variables landing in single quotes or quoted heredocs — clean. It was validated by confirming it detects 33 such problems in the unrepaired output for `url-validity-action`.
- Diff restricted to workflow and action definitions; no `dependabot.yml` or version-pin comment changes rode along

## Note on the generated names

Where `zizmor`'s names push a line past the length limit, the line carries a `yamllint disable-line` directive. Shortening them was rejected: the short forms are unique only *within* one `env:` block, so a global rewrite merges distinct variables and leaves dangling references — verified by observing exactly that failure.
